### PR TITLE
Update indentation rules

### DIFF
--- a/nand2tetris.el
+++ b/nand2tetris.el
@@ -228,7 +228,9 @@ Interactively, prompt for symbol."
   (beginning-of-line)
   (if (bobp)
       (indent-line-to 0)                   ; First line is always non-indented
-    (let ((not-indented t) cur-indent)
+    (let ((not-indented t)
+          (cur-indent 0)
+          (nand2tetris-1 -1))
       (if (looking-at "^[ \t]*}") ; If the line we are looking at is the end of a block, then decrease the indentation
           (progn
             (save-excursion
@@ -239,11 +241,11 @@ Interactively, prompt for symbol."
         (save-excursion
           (while not-indented ; Iterate backwards until we find an indentation hint
             (forward-line nand2tetris-1)
-            (if (looking-at "^[ \t]*}") ; This hint indicates that we need to indent at the level of the END_ token
+            (if (looking-at "^[ \t]*.*[})]") ; This hint indicates that we need to indent at the level of the END_ token
                 (progn
                   (setq cur-indent (current-indentation))
                   (setq not-indented nil))
-              (if (looking-at "^[ \t]*\\(CHIP\\)") ; This hint indicates that we need to indent an extra level
+              (if (looking-at "^[ \t]*.*[({]$") ; This hint indicates that we need to indent an extra level
                   (progn
                     (setq cur-indent (+ (current-indentation) tab-width)) ; Do the actual indenting
                     (setq not-indented nil))


### PR DESCRIPTION
1. Now something like the following will indent automatically so that people who want to adhere to 80 column lines can use the mode.

```
Mux(
    a=in,
    b=s0,
    sel=r0,
    out=out
);
```

2. Remove the CHIP regex and replace instead with the opening curly brace for a more general indentation rule.

3. Add a missing (previously undefined) variable - `nand2tetris-1` so the indentation works when called.

4. Add initial value to `cur-indented` for reading clarity.