### PR TITLE
Do not require yasnippet

### DIFF
--- a/nand2tetris.el
+++ b/nand2tetris.el
@@ -36,7 +36,6 @@
 ;;; Code:
 (require 'nand2tetris-core)
 (require 'eldoc)
-(require 'yasnippet)
 (require 'rx)
 
 


### PR DESCRIPTION
yasnippet is already removed[1] from Package-Requires.

ref: https://github.com/NixOS/nixpkgs/issues/335442

[1]: 0c63d09fbb4f091a30c838bcbeb86810836d59b3